### PR TITLE
Add .gitattribute to prevent failure deployment from Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.sh text eol=lf
+*.conf text eol=lf

--- a/cdsw-secure-cluster.conf
+++ b/cdsw-secure-cluster.conf
@@ -2,12 +2,9 @@ include file("your-aws-info.conf")
 
 ## Instance Configurations
 INSTANCE_TYPE_CM:        t2.xlarge    #vCPU 4, RAM 16G
-#INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
-#INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_MASTER:    m4.xlarge     #vCPU 2, RAM 8G
-INSTANCE_TYPE_WORKER:    m4.2xlarge     #vCPU 2, RAM 8G
-#INSTANCE_TYPE_CDSW:      t2.2xlarge   #vCPU 8, RAM 32G
-INSTANCE_TYPE_CDSW:      m4.2xlarge   #vCPU 8, RAM 32G
+INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_CDSW:      t2.2xlarge   #vCPU 8, RAM 32G
 
 WORKER_NODE_NUM:         3            #Number of Worker Nodes
 

--- a/cdsw-secure-cluster.conf
+++ b/cdsw-secure-cluster.conf
@@ -2,9 +2,12 @@ include file("your-aws-info.conf")
 
 ## Instance Configurations
 INSTANCE_TYPE_CM:        t2.xlarge    #vCPU 4, RAM 16G
-INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_CDSW:      t2.2xlarge   #vCPU 8, RAM 32G
+#INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
+#INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_MASTER:    m4.xlarge     #vCPU 2, RAM 8G
+INSTANCE_TYPE_WORKER:    m4.2xlarge     #vCPU 2, RAM 8G
+#INSTANCE_TYPE_CDSW:      t2.2xlarge   #vCPU 8, RAM 32G
+INSTANCE_TYPE_CDSW:      m4.2xlarge   #vCPU 8, RAM 32G
 
 WORKER_NODE_NUM:         3            #Number of Worker Nodes
 


### PR DESCRIPTION
With the default setting, git for Windows will convert shell scripts and conf files into CRLF automatically. That causes unexpected failure executing scripts for deployment on Linux environment.

This PR forces to keep shell scripts and conf files as LF for its line breaks.